### PR TITLE
SPARQLの改善

### DIFF
--- a/d3sparql-barchart.html
+++ b/d3sparql-barchart.html
@@ -57,7 +57,7 @@ PREFIX dbpedia-owl: <http://dbpedia.org/ontology/>
 
 SELECT ?pref ?area
 WHERE {
-  ?s a yago:PrefecturesOfJapan ;
+  ?s a yago:WikicatPrefecturesOfJapan ;
      rdfs:label ?pref ;
      dbpedia-owl:areaTotal ?area_total .
   FILTER (lang(?pref) = 'en')

--- a/d3sparql-circlepack.html
+++ b/d3sparql-circlepack.html
@@ -74,17 +74,18 @@
       </form>
       <textarea id="sparql" class="span9" rows=15>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX up: <http://purl.uniprot.org/core/>
-SELECT ?root_name ?parent_name ?child_name
-FROM <http://togogenome.org/graph/uniprot>
+PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+
+SELECT DISTINCT ?root_name ?parent_name ?child_name
+FROM <http://togogenome.org/graph/taxonomy>
 WHERE
 {
   VALUES ?root_name { "Tardigrada" }
-  ?root up:scientificName ?root_name .
+  ?root tax:scientificName ?root_name .
   ?child rdfs:subClassOf+ ?root .
   ?child rdfs:subClassOf ?parent .
-  ?child up:scientificName ?child_name .
-  ?parent up:scientificName ?parent_name .
+  ?child tax:scientificName ?child_name .
+  ?parent tax:scientificName ?parent_name .
 }
       </textarea>
     </div>

--- a/d3sparql-coordmap.html
+++ b/d3sparql-coordmap.html
@@ -40,23 +40,15 @@
       <form class="form-inline">
         <label>SPARQL endpoint:</label>
         <div class="input-append">
-          <input id="endpoint" class="span5" value="http://www.ebi.ac.uk/rdf/services/biosamples/sparql" type="text">
+          <input id="endpoint" class="span5" value="http://www.ebi.ac.uk/rdf/services/sparql" type="text">
           <button class="btn" type="button" onclick="exec()">Query</button>
           <button class="btn" type="button" onclick="exec_offline()">Use cache</button>
           <button class="btn" type="button" onclick="toggle()"><i id="button" class="icon-chevron-up"></i></button>
         </div>
       </form>
       <textarea id="sparql" class="span9" rows=15>
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX dc: <http://purl.org/dc/elements/1.1/>
-PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX obo: <http://purl.obolibrary.org/obo/>
-PREFIX efo: <http://www.ebi.ac.uk/efo/>
 PREFIX biosd-terms: <http://rdf.ebi.ac.uk/terms/biosd/>
-PREFIX pav: <http://purl.org/pav/2.0/>
-PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX sio: <http://semanticscience.org/resource/>
 
 # Samples reporting latitude and longitude

--- a/d3sparql-dendrogram.html
+++ b/d3sparql-dendrogram.html
@@ -48,18 +48,19 @@
         </div>
       </form>
       <textarea id="sparql" class="span9" rows=15>
-PREFIX up: <http://purl.uniprot.org/core/>
-PREFIX tax: <http://purl.uniprot.org/taxonomy/>
-SELECT ?root_name ?parent_name ?child_name
-FROM <http://togogenome.org/graph/uniprot>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+
+SELECT DISTINCT ?root_name ?parent_name ?child_name
+FROM <http://togogenome.org/graph/taxonomy>
 WHERE
 {
   VALUES ?root_name { "Tardigrada" }
-  ?root up:scientificName ?root_name .
+  ?root tax:scientificName ?root_name .
   ?child rdfs:subClassOf+ ?root .
   ?child rdfs:subClassOf ?parent .
-  ?child up:scientificName ?child_name .
-  ?parent up:scientificName ?parent_name .
+  ?child tax:scientificName ?child_name .
+  ?parent tax:scientificName ?parent_name .
 }
       </textarea>
     </div>

--- a/d3sparql-htmlhash.html
+++ b/d3sparql-htmlhash.html
@@ -32,7 +32,7 @@
       <form class="form-inline">
         <label>SPARQL endpoint:</label>
         <div class="input-append">
-          <input id="endpoint" class="span5" value="http://togostanza.org/sparql" type="text">
+          <input id="endpoint" class="span5" value="http://dbpedia.org/sparql" type="text">
           <button class="btn" type="button" onclick="exec()">Query</button>
           <button class="btn" type="button" onclick="exec_offline()">Use cache</button>
           <button class="btn" type="button" onclick="toggle()"><i id="button" class="icon-chevron-up"></i></button>
@@ -53,7 +53,7 @@ WHERE {
      rdfs:comment ?description ;
      dbo:developer/rdfs:label ?developer ;
      dbp:paradigm/rdfs:label ?paradigm ;
-     dbp:latestReleaseVersion ?version .
+     dbo:latestReleaseVersion ?version .
   FILTER (lang(?description) = 'en')
   FILTER (lang(?developer) = 'en')
   FILTER (lang(?paradigm) = 'en')

--- a/d3sparql-htmltable.html
+++ b/d3sparql-htmltable.html
@@ -43,18 +43,13 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX id_tax:<http://identifiers.org/taxonomy/>
 PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
 PREFIX stats:  <http://togogenome.org/stats/>
-PREFIX up_tax:<http://purl.uniprot.org/taxonomy/>
 PREFIX up: <http://purl.uniprot.org/core/>
 PREFIX ipr: <http://purl.uniprot.org/interpro/>
 
-SELECT DISTINCT ?taxid (SAMPLE(?label) AS ?label) (MAX(?length) AS ?length)  (MAX(?genes) AS ?genes) (MAX(?hks) AS ?hks)
+SELECT DISTINCT ?organism ?label ?length ?genes (COUNT(DISTINCT ?protein) AS ?hks)
 {
   {
-    SELECT DISTINCT
-     (REPLACE(STR(?organism),"http://identifiers.org/taxonomy/","") AS ?taxid)
-     ?organism ?label
-     ?length
-     ?genes
+    SELECT DISTINCT ?organism ?up_tax ?label ?length ?genes
     WHERE
     {
       ?organism a tax:Taxon ;
@@ -62,25 +57,15 @@ SELECT DISTINCT ?taxid (SAMPLE(?label) AS ?label) (MAX(?length) AS ?length)  (MA
         stats:sequence_length ?length ;
         stats:gene ?genes ;
         tax:scientificName ?label .
+        BIND (IRI(REPLACE(STR(?organism), "http://identifiers.org/taxonomy/", "http://purl.uniprot.org/taxonomy/")) AS ?up_tax)
     }
   }
-  UNION
-  {
-    SELECT DISTINCT
-     (REPLACE(STR(?organism),"http://purl.uniprot.org/taxonomy/","") AS ?taxid)
-     (COUNT(DISTINCT ?protein) AS ?hks)
-     ?label
-    WHERE
-    {
-      ?protein a up:Protein ;
-         up:organism ?organism .
-      ?organism rdfs:subClassOf up_tax:1117 ;
-        up:scientificName ?label .
-      # Signal transduction histidine kinase (IPR005467)
-      ?protein rdfs:seeAlso ipr:IPR005467 .
-    } GROUP BY ?organism ?label
-  }
-} GROUP BY ?taxid HAVING (SAMPLE(?hks) > 1)
+  ?up_tax a up:Taxon .
+  ?protein up:organism ?up_tax ;
+    a up:Protein .
+  # Signal transduction histidine kinase (IPR005467)
+  ?protein rdfs:seeAlso ipr:IPR005467 .
+} GROUP BY ?organism ?label ?length ?genes ORDER BY ?length
       </textarea>
     </div>
     <div id="result"></div>

--- a/d3sparql-htmltable.html
+++ b/d3sparql-htmltable.html
@@ -52,6 +52,7 @@ SELECT DISTINCT ?organism ?label ?length ?genes (COUNT(DISTINCT ?protein) AS ?hk
     SELECT DISTINCT ?organism ?up_tax ?label ?length ?genes
     WHERE
     {
+      # Cyanobacteria (1117)
       ?organism a tax:Taxon ;
         rdfs:subClassOf+ id_tax:1117 ;
         stats:sequence_length ?length ;

--- a/d3sparql-htmltable.html
+++ b/d3sparql-htmltable.html
@@ -39,42 +39,48 @@
         </div>
       </form>
       <textarea id="sparql" class="span9" rows=15>
-prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-prefix up: <http://purl.uniprot.org/core/>
-prefix obo: <http://purl.obolibrary.org/obo/>
-prefix tax: <http://purl.uniprot.org/taxonomy/>
-prefix insdc: <http://ddbj.nig.ac.jp/ontologies/nucleotide/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX id_tax:<http://identifiers.org/taxonomy/>
+PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+PREFIX stats:  <http://togogenome.org/stats/>
+PREFIX up_tax:<http://purl.uniprot.org/taxonomy/>
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX ipr: <http://purl.uniprot.org/interpro/>
 
-select distinct ?length ?genes ?hks ?taxid ?label
-where {
-  # Cyanobacteria (1117)
-  ?taxid rdfs:subClassOf+ <http://identifiers.org/taxonomy/1117> .
-  ?taxid rdf:type <http://identifiers.org/taxonomy> .
-  ?source rdfs:seeAlso ?taxid .
-  ?source obo:so_part_of ?seq .
-  ?entry insdc:sequence ?seq .
-  ?entry rdfs:label ?label .
-  ?seq rdfs:subClassOf obo:SO_0000340 . # chromosome
-  ?seq insdc:sequence_length ?length .
+SELECT DISTINCT ?taxid (SAMPLE(?label) AS ?label) (MAX(?length) AS ?length)  (MAX(?genes) AS ?genes) (MAX(?hks) AS ?hks)
+{
   {
-    select ?seq (count(?gene) as ?genes)
-    where {
-      ?gene obo:so_part_of ?seq .
-      ?gene rdfs:subClassOf obo:SO_0000704 . # gene
+    SELECT DISTINCT
+     (REPLACE(STR(?organism),"http://identifiers.org/taxonomy/","") AS ?taxid)
+     ?organism ?label
+     ?length
+     ?genes
+    WHERE
+    {
+      ?organism a tax:Taxon ;
+        rdfs:subClassOf+ id_tax:1117 ;
+        stats:sequence_length ?length ;
+        stats:gene ?genes ;
+        tax:scientificName ?label .
     }
-    group by ?seq
   }
+  UNION
   {
-    select ?seq (count(?cds) as ?hks)
-    where {
+    SELECT DISTINCT
+     (REPLACE(STR(?organism),"http://purl.uniprot.org/taxonomy/","") AS ?taxid)
+     (COUNT(DISTINCT ?protein) AS ?hks)
+     ?label
+    WHERE
+    {
+      ?protein a up:Protein ;
+         up:organism ?organism .
+      ?organism rdfs:subClassOf up_tax:1117 ;
+        up:scientificName ?label .
       # Signal transduction histidine kinase (IPR005467)
-      ?cds rdfs:seeAlso <http://identifiers.org/interpro/IPR005467> .
-      ?cds obo:so_part_of+ ?seq .
-    }
-    group by ?seq
+      ?protein rdfs:seeAlso ipr:IPR005467 .
+    } GROUP BY ?organism ?label
   }
-} order by desc(?genes) limit 100
+} GROUP BY ?taxid HAVING (SAMPLE(?hks) > 1)
       </textarea>
     </div>
     <div id="result"></div>

--- a/d3sparql-namedmap.html
+++ b/d3sparql-namedmap.html
@@ -56,7 +56,7 @@ PREFIX yago: <http://dbpedia.org/class/yago/>
 
 SELECT DISTINCT ?s ?label ?population ?area (?density AS ?size)
 WHERE {
-  ?s a yago:PrefecturesOfJapan ;
+  ?s a yago:WikicatPrefecturesOfJapan ;
      rdfs:label ?label ;
      dbpedia-owl:populationTotal ?population ;
      dbpedia-owl:areaTotal ?area .

--- a/d3sparql-piechart.html
+++ b/d3sparql-piechart.html
@@ -56,7 +56,7 @@ PREFIX dbpedia-owl: <http://dbpedia.org/ontology/>
 
 SELECT ?pref ?area
 WHERE {
-  ?s a yago:PrefecturesOfJapan ;
+  ?s a yago:WikicatPrefecturesOfJapan ;
      rdfs:label ?pref ;
      dbpedia-owl:areaTotal ?area_total .
   FILTER (lang(?pref) = 'en')

--- a/d3sparql-roundtree.html
+++ b/d3sparql-roundtree.html
@@ -49,17 +49,18 @@
       </form>
       <textarea id="sparql" class="span9" rows=15>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX up: <http://purl.uniprot.org/core/>
-SELECT ?root_name ?parent_name ?child_name
-FROM <http://togogenome.org/graph/uniprot>
+PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+
+SELECT DISTINCT ?root_name ?parent_name ?child_name
+FROM <http://togogenome.org/graph/taxonomy>
 WHERE
 {
   VALUES ?root_name { "Hypsibiidae" }
-  ?root up:scientificName ?root_name .
+  ?root tax:scientificName ?root_name .
   ?child rdfs:subClassOf+ ?root .
   ?child rdfs:subClassOf ?parent .
-  ?child up:scientificName ?child_name .
-  ?parent up:scientificName ?parent_name .
+  ?child tax:scientificName ?child_name .
+  ?parent tax:scientificName ?parent_name .
 }
       </textarea>
     </div>

--- a/d3sparql-sankey.html
+++ b/d3sparql-sankey.html
@@ -87,11 +87,9 @@ WHERE {
           dbpprop:year ?child_year .
   ?root   dbpedia-owl:influenced* ?child .
   ?parent dbpedia-owl:influenced ?child .
-  BIND (xsd:integer(?parent_year) AS ?pyear)
-  FILTER (?pyear > 1950 and ?pyear < 2020)
-  BIND (xsd:integer(?child_year) AS ?cyear)
-  FILTER (?cyear > 1950 and ?cyear < 2020)
-  FILTER (?pyear < ?cyear)
+  FILTER (?parent_year > 1950 and ?parent_year < 2020)
+  FILTER (?child_year > 1950 and ?child_year < 2020)
+  FILTER (?parent_year < ?child_year)
   FILTER (?root != ?child)
   FILTER (?parent != ?child)
   FILTER (LANG(?root_label) = 'en')

--- a/d3sparql-scatterplot.html
+++ b/d3sparql-scatterplot.html
@@ -51,42 +51,48 @@
         </div>
       </form>
       <textarea id="sparql" class="span9" rows=15>
-prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-prefix up: <http://purl.uniprot.org/core/>
-prefix obo: <http://purl.obolibrary.org/obo/>
-prefix tax: <http://purl.uniprot.org/taxonomy/>
-prefix insdc: <http://ddbj.nig.ac.jp/ontologies/nucleotide/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX id_tax:<http://identifiers.org/taxonomy/>
+PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+PREFIX stats:  <http://togogenome.org/stats/>
+PREFIX up_tax:<http://purl.uniprot.org/taxonomy/>
+PREFIX up: <http://purl.uniprot.org/core/>
+PREFIX ipr: <http://purl.uniprot.org/interpro/>
 
-select distinct ?length ?genes ?hks ?taxid ?label
-where {
-  # Cyanobacteria (1117)
-  ?taxid rdfs:subClassOf+ <http://identifiers.org/taxonomy/1117> .
-  ?taxid rdf:type <http://identifiers.org/taxonomy> .
-  ?source rdfs:seeAlso ?taxid .
-  ?source obo:so_part_of ?seq .
-  ?entry insdc:sequence ?seq .
-  ?entry rdfs:label ?label .
-  ?seq rdfs:subClassOf obo:SO_0000340 . # chromosome
-  ?seq insdc:sequence_length ?length .
+SELECT DISTINCT ?taxid (SAMPLE(?label) AS ?label) (MAX(?length) AS ?length)  (MAX(?genes) AS ?genes) (MAX(?hks) AS ?hks)
+{
   {
-    select ?seq (count(?gene) as ?genes)
-    where {
-      ?gene obo:so_part_of ?seq .
-      ?gene rdfs:subClassOf obo:SO_0000704 . # gene
+    SELECT DISTINCT
+     (REPLACE(STR(?organism),"http://identifiers.org/taxonomy/","") AS ?taxid)
+     ?organism ?label
+     ?length
+     ?genes
+    WHERE
+    {
+      ?organism a tax:Taxon ;
+        rdfs:subClassOf+ id_tax:1117 ;
+        stats:sequence_length ?length ;
+        stats:gene ?genes ;
+        tax:scientificName ?label .
     }
-    group by ?seq
   }
+  UNION
   {
-    select ?seq (count(?cds) as ?hks)
-    where {
+    SELECT DISTINCT
+     (REPLACE(STR(?organism),"http://purl.uniprot.org/taxonomy/","") AS ?taxid)
+     (COUNT(DISTINCT ?protein) AS ?hks)
+     ?label
+    WHERE
+    {
+      ?protein a up:Protein ;
+         up:organism ?organism .
+      ?organism rdfs:subClassOf up_tax:1117 ;
+        up:scientificName ?label .
       # Signal transduction histidine kinase (IPR005467)
-      ?cds rdfs:seeAlso <http://identifiers.org/interpro/IPR005467> .
-      ?cds obo:so_part_of+ ?seq .
-    }
-    group by ?seq
+      ?protein rdfs:seeAlso ipr:IPR005467 .
+    } GROUP BY ?organism ?label
   }
-} order by desc(?genes) limit 100
+} GROUP BY ?taxid HAVING (SAMPLE(?hks) > 1)
       </textarea>
     </div>
     <div id="result"></div>

--- a/d3sparql-scatterplot.html
+++ b/d3sparql-scatterplot.html
@@ -55,18 +55,13 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX id_tax:<http://identifiers.org/taxonomy/>
 PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
 PREFIX stats:  <http://togogenome.org/stats/>
-PREFIX up_tax:<http://purl.uniprot.org/taxonomy/>
 PREFIX up: <http://purl.uniprot.org/core/>
 PREFIX ipr: <http://purl.uniprot.org/interpro/>
 
-SELECT DISTINCT ?taxid (SAMPLE(?label) AS ?label) (MAX(?length) AS ?length)  (MAX(?genes) AS ?genes) (MAX(?hks) AS ?hks)
+SELECT DISTINCT ?organism ?label ?length ?genes (COUNT(DISTINCT ?protein) AS ?hks)
 {
   {
-    SELECT DISTINCT
-     (REPLACE(STR(?organism),"http://identifiers.org/taxonomy/","") AS ?taxid)
-     ?organism ?label
-     ?length
-     ?genes
+    SELECT DISTINCT ?organism ?up_tax ?label ?length ?genes
     WHERE
     {
       ?organism a tax:Taxon ;
@@ -74,25 +69,15 @@ SELECT DISTINCT ?taxid (SAMPLE(?label) AS ?label) (MAX(?length) AS ?length)  (MA
         stats:sequence_length ?length ;
         stats:gene ?genes ;
         tax:scientificName ?label .
+        BIND (IRI(REPLACE(STR(?organism), "http://identifiers.org/taxonomy/", "http://purl.uniprot.org/taxonomy/")) AS ?up_tax)
     }
   }
-  UNION
-  {
-    SELECT DISTINCT
-     (REPLACE(STR(?organism),"http://purl.uniprot.org/taxonomy/","") AS ?taxid)
-     (COUNT(DISTINCT ?protein) AS ?hks)
-     ?label
-    WHERE
-    {
-      ?protein a up:Protein ;
-         up:organism ?organism .
-      ?organism rdfs:subClassOf up_tax:1117 ;
-        up:scientificName ?label .
-      # Signal transduction histidine kinase (IPR005467)
-      ?protein rdfs:seeAlso ipr:IPR005467 .
-    } GROUP BY ?organism ?label
-  }
-} GROUP BY ?taxid HAVING (SAMPLE(?hks) > 1)
+  ?up_tax a up:Taxon .
+  ?protein up:organism ?up_tax ;
+    a up:Protein .
+  # Signal transduction histidine kinase (IPR005467)
+  ?protein rdfs:seeAlso ipr:IPR005467 .
+} GROUP BY ?organism ?label ?length ?genes ORDER BY ?length
       </textarea>
     </div>
     <div id="result"></div>

--- a/d3sparql-scatterplot.html
+++ b/d3sparql-scatterplot.html
@@ -64,6 +64,7 @@ SELECT DISTINCT ?organism ?label ?length ?genes (COUNT(DISTINCT ?protein) AS ?hk
     SELECT DISTINCT ?organism ?up_tax ?label ?length ?genes
     WHERE
     {
+      # Cyanobacteria (1117)
       ?organism a tax:Taxon ;
         rdfs:subClassOf+ id_tax:1117 ;
         stats:sequence_length ?length ;

--- a/d3sparql-sunburst.html
+++ b/d3sparql-sunburst.html
@@ -48,17 +48,18 @@
       </form>
       <textarea id="sparql" class="span9" rows=15>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX up: <http://purl.uniprot.org/core/>
-SELECT ?root_name ?parent_name ?child_name
-FROM <http://togogenome.org/graph/uniprot>
+PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+
+SELECT DISTINCT ?root_name ?parent_name ?child_name
+FROM <http://togogenome.org/graph/taxonomy>
 WHERE
 {
-  VALUES ?root_name {"Tardigrada"} .
-  ?root up:scientificName ?root_name .
+  VALUES ?root_name { "Tardigrada" }
+  ?root tax:scientificName ?root_name .
   ?child rdfs:subClassOf+ ?root .
   ?child rdfs:subClassOf ?parent .
-  ?child up:scientificName ?child_name .
-  ?parent up:scientificName ?parent_name .
+  ?child tax:scientificName ?child_name .
+  ?parent tax:scientificName ?parent_name .
 }
       </textarea>
     </div>

--- a/d3sparql-treemap.html
+++ b/d3sparql-treemap.html
@@ -47,17 +47,18 @@
       </form>
       <textarea id="sparql" class="span9" rows=15>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX up: <http://purl.uniprot.org/core/>
-SELECT ?root_name ?parent_name ?child_name
-FROM <http://togogenome.org/graph/uniprot>
+PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+
+SELECT DISTINCT ?root_name ?parent_name ?child_name
+FROM <http://togogenome.org/graph/taxonomy>
 WHERE
 {
   VALUES ?root_name { "Tardigrada" }
-  ?root up:scientificName ?root_name .
+  ?root tax:scientificName ?root_name .
   ?child rdfs:subClassOf+ ?root .
   ?child rdfs:subClassOf ?parent .
-  ?child up:scientificName ?child_name .
-  ?parent up:scientificName ?parent_name .
+  ?child tax:scientificName ?child_name .
+  ?parent tax:scientificName ?parent_name .
 }
       </textarea>
     </div>

--- a/d3sparql-treemapzoom.html
+++ b/d3sparql-treemapzoom.html
@@ -75,6 +75,7 @@ WHERE
         ?root skos:narrowerTransitive* ?enzyme .
         ?parent skos:narrowerTransitive ?enzyme .
         ?protein up:enzyme ?enzyme .
+        # Homo sapiens (9606)
         ?protein up:organism taxon:9606
 }
 GROUP BY ?root ?parent ?enzyme ORDER BY ?enzyme

--- a/d3sparql-treemapzoom.html
+++ b/d3sparql-treemapzoom.html
@@ -57,12 +57,13 @@
         </div>
       </form>
       <textarea id="sparql" class="span9" rows=15>
-# This may take a while to get results
 PREFIX up: <http://purl.uniprot.org/core/>
 PREFIX ec: <http://purl.uniprot.org/enzyme/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-SELECT  (REPLACE(STR(?root), ".*/", "") AS ?root_label)
+PREFIX taxon:<http://purl.uniprot.org/taxonomy/>
+
+SELECT (REPLACE(STR(?root), ".*/", "") AS ?root_label)
         (REPLACE(STR(?parent), ".*/", "") AS ?parent_label)
         (REPLACE(STR(?enzyme), ".*/", "") AS ?enzyme_label)
         (COUNT(?protein) AS ?value)
@@ -70,9 +71,11 @@ FROM <http://togogenome.org/graph/uniprot>
 WHERE
 {
         VALUES ?root { ec:1.-.-.- }
+        ?root a up:Enzyme .
         ?root skos:narrowerTransitive* ?enzyme .
         ?parent skos:narrowerTransitive ?enzyme .
         ?protein up:enzyme ?enzyme .
+        ?protein up:organism taxon:9606
 }
 GROUP BY ?root ?parent ?enzyme ORDER BY ?enzyme
       </textarea>


### PR DESCRIPTION
- d3barchart, d3piechart, d3namedmap, d3htmlhash
DBpediaで使用されているクラス名、プロパティ名が変わっていたため修正
- d3scatterplot, d3htmltable
refseqデータにIPR番号の記載されるケースが減っていたためUniprotから取得するように修正
- d3sankey
?parent_yearにintegerではない型が含まれていてエラーになっていたので無理に型変換をしないように修正
- d3roundtree, d3dendrogram, d3treemap, d3sunburst, d3circlepack
uniprotグラフにはのtaxonomyのrdfs:subClassOfの関係が展開されている(全祖先に貼られている)ためproperty pathを使用すると数が膨大になる。uniprotグラフを使わずtaxonomyグラフを使用するよう変更
- d3treemapzoom
結果件数が多く重たくなっていたためtax:9606でのフィルタリングを追加
- d3coordmap
EBIのエンドポイントが変更されていたので修正
