### PR TITLE
Prepare to publish as npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/dist/
+/ktym-d3sparql-*.tgz
+/lib/
+/node_modules/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+/*.html
+/ktym-d3sparql-*.tgz
+/lib/
+/rollup.config.js

--- a/d3sparql-barchart.html
+++ b/d3sparql-barchart.html
@@ -4,7 +4,7 @@
   <head>
     <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css"/>
     <script src="lib/d3/d3.v3.min.js"></script>
-    <script src="d3sparql.js"></script>
+    <script src="dist/d3sparql.js"></script>
     <script>
     function exec() {
       var endpoint = d3.select("#endpoint").property("value")

--- a/d3sparql-circlepack.html
+++ b/d3sparql-circlepack.html
@@ -4,7 +4,7 @@
   <head>
     <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css"/>
     <script src="lib/d3/d3.v3.min.js"></script>
-    <script src="d3sparql.js"></script>
+    <script src="dist/d3sparql.js"></script>
     <script>
     function exec() {
       var endpoint = d3.select("#endpoint").property("value")

--- a/d3sparql-coordmap.html
+++ b/d3sparql-coordmap.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css"/>
     <script src="lib/d3/d3.v3.min.js"></script>
     <script src="lib/d3/topojson.v1.min.js"></script>
-    <script src="d3sparql.js"></script>
+    <script src="dist/d3sparql.js"></script>
     <script>
     function exec() {
       var endpoint = d3.select("#endpoint").property("value")

--- a/d3sparql-dendrogram.html
+++ b/d3sparql-dendrogram.html
@@ -4,7 +4,7 @@
   <head>
     <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css"/>
     <script src="lib/d3/d3.v3.min.js"></script>
-    <script src="d3sparql.js"></script>
+    <script src="dist/d3sparql.js"></script>
     <script>
     function exec() {
       var endpoint = d3.select("#endpoint").property("value")

--- a/d3sparql-forcegraph.html
+++ b/d3sparql-forcegraph.html
@@ -4,7 +4,7 @@
   <head>
     <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css"/>
     <script src="lib/d3/d3.v3.min.js"></script>
-    <script src="d3sparql.js"></script>
+    <script src="dist/d3sparql.js"></script>
     <script>
     function exec() {
       var endpoint = d3.select("#endpoint").property("value")

--- a/d3sparql-htmlhash.html
+++ b/d3sparql-htmlhash.html
@@ -4,7 +4,7 @@
   <head>
     <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css"/>
     <script src="lib/d3/d3.v3.min.js"></script>
-    <script src="d3sparql.js"></script>
+    <script src="dist/d3sparql.js"></script>
     <script>
     function exec() {
       var endpoint = d3.select("#endpoint").property("value")

--- a/d3sparql-htmltable.html
+++ b/d3sparql-htmltable.html
@@ -4,7 +4,7 @@
   <head>
     <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css"/>
     <script src="lib/d3/d3.v3.min.js"></script>
-    <script src="d3sparql.js"></script>
+    <script src="dist/d3sparql.js"></script>
     <script>
     function exec() {
       var endpoint = d3.select("#endpoint").property("value")

--- a/d3sparql-namedmap.html
+++ b/d3sparql-namedmap.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css"/>
     <script src="lib/d3/d3.v3.min.js"></script>
     <script src="lib/d3/topojson.v0.min.js"></script>
-    <script src="d3sparql.js"></script>
+    <script src="dist/d3sparql.js"></script>
     <script>
     function exec() {
       var endpoint = d3.select("#endpoint").property("value")

--- a/d3sparql-piechart.html
+++ b/d3sparql-piechart.html
@@ -4,7 +4,7 @@
   <head>
     <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css"/>
     <script src="lib/d3/d3.v3.min.js"></script>
-    <script src="d3sparql.js"></script>
+    <script src="dist/d3sparql.js"></script>
     <script>
     function exec() {
       var endpoint = d3.select("#endpoint").property("value")

--- a/d3sparql-roundtree.html
+++ b/d3sparql-roundtree.html
@@ -4,7 +4,7 @@
   <head>
     <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css"/>
     <script src="lib/d3/d3.v3.min.js"></script>
-    <script src="d3sparql.js"></script>
+    <script src="dist/d3sparql.js"></script>
     <script>
     function exec() {
       var endpoint = d3.select("#endpoint").property("value")

--- a/d3sparql-sankey.html
+++ b/d3sparql-sankey.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css"/>
     <script src="lib/d3/d3.v3.min.js"></script>
     <script src="lib/d3/sankey.js"></script>
-    <script src="d3sparql.js"></script>
+    <script src="dist/d3sparql.js"></script>
     <script>
     function exec() {
       var endpoint = d3.select("#endpoint").property("value")

--- a/d3sparql-scatterplot.html
+++ b/d3sparql-scatterplot.html
@@ -4,7 +4,7 @@
   <head>
     <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css"/>
     <script src="lib/d3/d3.v3.min.js"></script>
-    <script src="d3sparql.js"></script>
+    <script src="dist/d3sparql.js"></script>
     <script>
     function exec() {
       var endpoint = d3.select("#endpoint").property("value")

--- a/d3sparql-sunburst.html
+++ b/d3sparql-sunburst.html
@@ -4,7 +4,7 @@
   <head>
     <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css"/>
     <script src="lib/d3/d3.v3.min.js"></script>
-    <script src="d3sparql.js"></script>
+    <script src="dist/d3sparql.js"></script>
     <script>
     function exec() {
       var endpoint = d3.select("#endpoint").property("value")

--- a/d3sparql-treemap.html
+++ b/d3sparql-treemap.html
@@ -4,7 +4,7 @@
   <head>
     <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css"/>
     <script src="lib/d3/d3.v3.min.js"></script>
-    <script src="d3sparql.js"></script>
+    <script src="dist/d3sparql.js"></script>
     <script>
     function exec() {
       var endpoint = d3.select("#endpoint").property("value")

--- a/d3sparql-treemapzoom.html
+++ b/d3sparql-treemapzoom.html
@@ -4,7 +4,7 @@
   <head>
     <link rel="stylesheet" type="text/css" href="lib/bootstrap/css/bootstrap.css"/>
     <script src="lib/d3/d3.v3.min.js"></script>
-    <script src="d3sparql.js"></script>
+    <script src="dist/d3sparql.js"></script>
     <script>
     function exec() {
       d3sparql.debug = true

--- a/d3sparql.html
+++ b/d3sparql.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" type="text/css" href="lib/google-code-prettify/prettify-desert.css"/>
     <script src="lib/google-code-prettify/prettify.js"></script>
     <script>
-    $.get("d3sparql.js", function(data) {
+    $.get("src/d3sparql.mjs", function(data) {
       $("#code").text(data);
       prettyPrint();
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,261 @@
+{
+  "name": "@ktym/d3sparql",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@rollup/plugin-commonjs": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-15.1.0.tgz",
+      "integrity": "sha512-xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
+          "integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==",
+          "dev": true
+        }
+      }
+    },
+    "@rollup/plugin-node-resolve": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-9.0.0.tgz",
+      "integrity": "sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "builtin-modules": "^3.1.0",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.17.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.11.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
+      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+      "dev": true
+    },
+    "@types/resolve": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "builtin-modules": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
+      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "d3": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
+    "is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "rollup": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.29.0.tgz",
+      "integrity": "sha512-gtU0sjxMpsVlpuAf4QXienPmUAhd6Kc7owQ4f5lypoxBW18fw2UNYZ4NssLGsri6WhUZkE/Ts3EMRebN+gNLiQ==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.1.2"
+      }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@ktym/d3sparql",
+  "version": "0.0.0",
+  "description": "JavaScript library for executing SPARQL query and transforming resulted JSON for visualization in D3.js.",
+  "author": "Toshiaki Katayama <ktym@dbcls.jp>",
+  "license": "BSD-3-Clause",
+  "homepage": "https://github.com/ktym/d3sparql",
+  "repository": "https://github.com/ktym/d3sparql.git",
+  "module": "src/d3sparql.mjs",
+  "main": "dist/d3sparql.cjs",
+  "browser": "dist/d3sparql.js",
+  "scripts": {
+    "prepare": "npm run build",
+    "build": "rollup --config"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^15.1.0",
+    "@rollup/plugin-node-resolve": "^9.0.0",
+    "rollup": "^2.29.0"
+  },
+  "dependencies": {
+    "d3": "^3.5.17"
+  }
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,35 @@
+import commonjs from '@rollup/plugin-commonjs';
+import nodeResolve from '@rollup/plugin-node-resolve';
+
+export default {
+  input: 'src/d3sparql.mjs',
+
+  output: [
+    {
+      file:    'dist/d3sparql.cjs',
+      strict:  false, // d3.js is incompatible with strict mode because it accesses this.document
+      format:  'cjs',
+      exports: 'default'
+    },
+
+    {
+      file:   'dist/d3sparql.js',
+      strict:  false,
+      format: 'iife',
+      name:   'd3sparql',
+
+      globals: {
+        d3: 'd3'
+      }
+    }
+  ],
+
+  plugins: [
+    nodeResolve(),
+    commonjs()
+  ],
+
+  external: [
+    'd3'
+  ]
+};

--- a/src/d3sparql.mjs
+++ b/src/d3sparql.mjs
@@ -7,6 +7,8 @@
 //   Initial version: 2013-01-28
 //
 
+import d3 from "d3";
+
 var d3sparql = {
   version: "d3sparql.js version 2018-05-04",
   debug: false  // set to true for showing debug information
@@ -2046,5 +2048,4 @@ d3sparql.frameheight = function(height) {
   d3.select(self.frameElement).style("height", height + "px")
 }
 
-/* for Node.js */
-//module.exports = d3sparql
+export default d3sparql;


### PR DESCRIPTION
I have prepared to publish d3sparql.js as npm package.

It automatically generates Node.js build (`dist/d3sparql.cjs`) and browser build (`dist/d3sparql.js`) from the source code using the ECMAScript module (`src/d3sparql.mjs`). This is a similar mechanism to sparql-support.

There is already a library named `d3-sparql`, and npm didn't allow us to give it a similar name. Hence the name of this package is `@ktym/d3sparql`.

As an example, here's how to use this package from TogoStanza:

``` sh
$ npm install @kytm/d3sparql
```

``` js
// stanzas/foo/index.js
import d3sparql from '@ktym/d3sparql';
```

After merging the pull request, follow these steps:

1. `npm version minor`: Increment the package version (0.0.0 -> 0.1.0 in this case), commit and create a git tag
2. `git push --tags`: Push that commit and tag to GitHub
3. `npm publish --access public`: Submit this package to the npm registry